### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ msgInit : {
     }
 }
 ```
+
+*The 'cmd' property must be present if you decide to specify additional options*
+
 #### options.msgMerge
 Type: `Object`
 
@@ -120,3 +123,4 @@ msgMerge : {
     }
 }
 ```
+*The 'cmd' property must be present if you decide to specify additional options*


### PR DESCRIPTION
I scratched my head for a while until I figured it out the 'cmd' property becomes mandatory when you specify additional options. Ideally you could fix the source but in the mean time I believe it's best to let a warning.
