### PR TITLE
added potDirName as potFilePath variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ tmp/i18n/<%= locale%>/<%= potFileName%>.po
 Available variables:
 * locale - locale folder
 * potFileName - name of a *.pot file
+* potDirName - dir path of a *.pot file
 
 #### options.msgInit
 Type: `Object`

--- a/tasks/msgInitMerge.js
+++ b/tasks/msgInitMerge.js
@@ -72,7 +72,8 @@ module.exports = function (grunt) {
 					poFilePath = grunt.template.process(poFilesPath, {
 						data : {
 							locale: localeFolder,
-							potFileName: potFileName
+							potFileName: potFileName,
+							potDirName: path.dirname(potFilePath)
 						}
 					});
 


### PR DESCRIPTION
Currently its not possible to create the po file in the same directory as the pot file, because options.poFilesPath misses a variable for the path of the pot file.

I added the variable potDirName. Now its possible to use grunt-msg-init-merge like this:

```
    src: ['myRepo/widgets/**/potFiles/*.pot'],
        options: {
            locales: ['en', 'de'],
            poFilesPath: '<%= potDirName %>/../poFiles/<%= potFileName%>.po'
        }
```

myRepo/widgets/chart/potFiles/en.pot
-->
myRepo/widgets/chart/poFiles/en.po
